### PR TITLE
Enable dynamic widget data fetching

### DIFF
--- a/app/src/custom-aurora-components/timer/timer.tsx
+++ b/app/src/custom-aurora-components/timer/timer.tsx
@@ -1,12 +1,19 @@
 import React, { useState, useEffect } from 'react'
-import { CircularProgress, Flexbox, Text } from '@leon-ai/aurora'
+import {
+  WidgetWrapper,
+  CircularProgress,
+  Flexbox,
+  Text,
+  IconButton
+} from '@leon-ai-ai/aurora'
 
 interface TimerProps {
   initialTime: number
+  initialProgress: number
   interval: number
   totalTimeContent: string
-  initialProgress?: number
-  onEnd?: () => void
+  onEnd: () => void
+  onCheck: () => void
 }
 
 function formatTime(seconds: number): string {
@@ -19,20 +26,14 @@ function formatTime(seconds: number): string {
   return `${formattedMinutes}:${formattedSeconds}`
 }
 
-export function Timer({
-  initialTime,
-  initialProgress,
-  interval,
-  totalTimeContent,
-  onEnd
-}: TimerProps) {
-  const [progress, setProgress] = useState(initialProgress || 0)
-  const [timeLeft, setTimeLeft] = useState(initialTime)
+export const Timer = (props: TimerProps): JSX.Element => {
+  const [progress, setProgress] = useState(props.initialProgress || 0)
+  const [timeLeft, setTimeLeft] = useState(props.initialTime)
 
   useEffect(() => {
-    setTimeLeft(initialTime)
+    setTimeLeft(props.initialTime)
     setProgress(progress)
-  }, [initialTime])
+  }, [props.initialTime])
 
   useEffect(() => {
     if (timeLeft <= 0) {
@@ -43,28 +44,42 @@ export function Timer({
       setTimeLeft((prevTime) => {
         const newTime = prevTime - 1
 
-        if (newTime <= 0 && onEnd) {
-          onEnd()
+        if (newTime <= 0 && props.onEnd) {
+          props.onEnd()
         }
 
         return newTime
       })
-      setProgress((prevProgress) => prevProgress + 100 / initialTime)
-    }, interval)
+      setProgress((prevProgress) => prevProgress + 100 / props.initialTime)
+    }, props.interval)
 
     return () => clearInterval(timer)
-  }, [initialTime, interval, timeLeft])
+  }, [props.initialTime, props.interval, timeLeft])
 
   return (
-    <CircularProgress value={progress} size="lg">
-      <Flexbox gap="xs" alignItems="center" justifyContent="center">
+    <WidgetWrapper>
+      <Flexbox
+        gap="xs"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <CircularProgress value={progress} />
+        <IconButton
+          icon="refresh"
+          aria-label="Refresh"
+          tooltip="Refresh"
+          variant="ghost"
+          onClick={props.onCheck}
+        />
+      </Flexbox>
+      <Flexbox direction="column" gap="xs" alignItems="center">
         <Text fontSize="lg" fontWeight="semi-bold">
           {formatTime(timeLeft)}
         </Text>
         <Text fontSize="xs" secondary>
-          {totalTimeContent}
+          {props.totalTimeContent}
         </Text>
       </Flexbox>
-    </CircularProgress>
+    </WidgetWrapper>
   )
 }

--- a/app/src/js/chatbot.js
+++ b/app/src/js/chatbot.js
@@ -18,6 +18,24 @@ export default class Chatbot {
     this.noBubbleMessage = document.querySelector('#no-bubble')
     this.bubbles = localStorage.getItem('bubbles')
     this.parsedBubbles = JSON.parse(this.bubbles)
+
+    this.socket.on('widget-data-fetched', (event) => {
+      const { widget } = event
+      const widgetContainer = document.querySelector(
+        `[data-widget-id="${widget.id}"]`
+      )
+
+      if (widgetContainer) {
+        const root = createRoot(widgetContainer)
+        const reactNode = renderAuroraComponent(
+          this.socket,
+          widget.componentTree,
+          widget.supportedEvents
+        )
+
+        root.render(reactNode)
+      }
+    })
   }
 
   async init() {

--- a/bridges/nodejs/src/sdk/widget.ts
+++ b/bridges/nodejs/src/sdk/widget.ts
@@ -24,7 +24,7 @@ interface SendUtteranceOptions {
 }
 
 export interface WidgetEventMethod {
-  methodName: 'send_utterance' | 'run_skill_action'
+  methodName: 'send_utterance' | 'run_skill_action' | 'fetch_widget_data'
   methodParams:
     | SendUtteranceWidgetEventMethodParams
     | RunSkillActionWidgetEventMethodParams
@@ -32,6 +32,10 @@ export interface WidgetEventMethod {
 }
 export interface WidgetOptions<T = unknown> {
   wrapperProps?: Omit<WidgetWrapperProps, 'children'>
+  onFetch?: {
+    actionName: string
+    initialParams?: Record<string, unknown>
+  }
   onFetchAction?: string
   params: T
 }
@@ -40,6 +44,7 @@ export abstract class Widget<T = unknown> {
   public actionName: string
   public id: string
   public widget: string
+  public onFetch: WidgetOptions<T>['onFetch'] = undefined
   public onFetchAction: string | null = null
   public wrapperProps: WidgetOptions<T>['wrapperProps']
   public params: WidgetOptions<T>['params']
@@ -47,6 +52,10 @@ export abstract class Widget<T = unknown> {
   protected constructor(options: WidgetOptions<T>) {
     if (options?.wrapperProps) {
       this.wrapperProps = options.wrapperProps
+    }
+    if (options?.onFetch) {
+      this.onFetch = options.onFetch
+      this.onFetch.actionName = `${INTENT_OBJECT.domain}:${INTENT_OBJECT.skill}:${this.onFetch.actionName}`
     }
     if (options?.onFetchAction) {
       this.onFetchAction = `${INTENT_OBJECT.domain}:${INTENT_OBJECT.skill}:${options.onFetchAction}`
@@ -101,6 +110,26 @@ export abstract class Widget<T = unknown> {
       methodParams: {
         actionName,
         params
+      }
+    }
+  }
+
+  /**
+   * Indicate the core to fetch widget data
+   * @param actionName The name of the action
+   * @param dataToSet The data to set
+   * @example fetchWidgetData('music_audio:player:next', { provider: 'Spotify' })
+   */
+  protected fetchWidgetData(
+    actionName: string,
+    dataToSet: string[]
+  ): WidgetEventMethod {
+    return {
+      methodName: 'fetch_widget_data',
+      methodParams: {
+        actionName,
+        widgetId: this.id,
+        dataToSet
       }
     }
   }

--- a/bridges/python/src/sdk/widget.py
+++ b/bridges/python/src/sdk/widget.py
@@ -45,6 +45,7 @@ class WidgetEventMethod(TypedDict):
 class WidgetOptions(Generic[T]):
     wrapper_props: dict[str, Any] = None
     params: T = None
+    on_fetch: Optional[Dict[str, Any]] = None
     on_fetch_action: Optional[str] = None
 
 
@@ -55,6 +56,10 @@ class Widget(ABC, Generic[T]):
         self.id = f"{self.widget.lower()}-{random.randint(100000, 999999)}"
         self.wrapper_props = options.wrapper_props
         self.params = options.params
+        self.on_fetch = None
+        if options.on_fetch:
+            self.on_fetch = options.on_fetch
+            self.on_fetch['actionName'] = f"{INTENT_OBJECT['domain']}:{INTENT_OBJECT['skill']}:{self.on_fetch['actionName']}"
         self.on_fetch_action = f"{INTENT_OBJECT['domain']}:{INTENT_OBJECT['skill']}:{options.on_fetch_action}" \
             if options.on_fetch_action else None
 
@@ -90,6 +95,21 @@ class Widget(ABC, Generic[T]):
             methodParams={
                 'actionName': action_name,
                 'params': params
+            }
+        )
+
+    def fetch_widget_data(self, action_name: str, data_to_set: list[str]) -> WidgetEventMethod:
+        """
+        Indicate the core to fetch widget data
+        :param action_name: The name of the action
+        :param data_to_set: The data to set
+        """
+        return WidgetEventMethod(
+            methodName='fetch_widget_data',
+            methodParams={
+                'actionName': action_name,
+                'widgetId': self.id,
+                'dataToSet': data_to_set
             }
         )
 

--- a/server/src/core/http-server/api/fetch-widget/index.ts
+++ b/server/src/core/http-server/api/fetch-widget/index.ts
@@ -3,6 +3,9 @@ import type { FastifyPluginAsync } from 'fastify'
 import { fetchWidget } from '@/core/http-server/api/fetch-widget/get'
 import type { APIOptions } from '@/core/http-server/http-server'
 
+export { fetchWidget as getFetchWidget } from './get'
+export { fetchWidget as postFetchWidget } from './post'
+
 export const fetchWidgetPlugin: FastifyPluginAsync<APIOptions> = async (
   fastify,
   options

--- a/server/src/core/http-server/api/fetch-widget/post.ts
+++ b/server/src/core/http-server/api/fetch-widget/post.ts
@@ -1,0 +1,127 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+import type { APIOptions } from '@/core/http-server/http-server'
+import { BRAIN } from '@/core'
+import { LogHelper } from '@/helpers/log-helper'
+import { DEFAULT_NLU_RESULT } from '@/core/nlp/nlu/nlu'
+import { SkillDomainHelper } from '@/helpers/skill-domain-helper'
+
+export const fetchWidget: FastifyPluginAsync<APIOptions> = async (
+  fastify,
+  options
+) => {
+  fastify.route({
+    method: 'POST',
+    url: `/api/${options.apiVersion}/fetch-widget`,
+    handler: async (_request, reply) => {
+      let message
+
+      try {
+        const body = _request.body as Record<string, string>
+        const { skill_action: skillAction, widget_id: widgetId, params } = body
+
+        if (!skillAction || !widgetId) {
+          reply.statusCode = 400
+          message = 'skill_action and widget_id are missing.'
+          LogHelper.title('POST /fetch-widget')
+          LogHelper.warning(message)
+          return reply.send({
+            success: false,
+            status: reply.statusCode,
+            code: 'missing_params',
+            message,
+            widget: null
+          })
+        }
+
+        const [domain, skill, action] = skillAction.split(':')
+
+        if (!domain || !skill || !action) {
+          message = 'skill_action is not well formatted.'
+          LogHelper.title('POST /fetch-widget')
+          LogHelper.warning(message)
+          return reply.send({
+            success: false,
+            status: reply.statusCode,
+            code: 'skill_action_not_valid',
+            message,
+            widget: null
+          })
+        }
+
+        // Do not return any speech and new widget
+        BRAIN.isMuted = true
+        await BRAIN.execute({
+          ...DEFAULT_NLU_RESULT,
+          currentEntities: [
+            {
+              start: 0,
+              end: widgetId.length - 1,
+              len: widgetId.length,
+              levenshtein: 0,
+              accuracy: 1,
+              entity: 'widgetid',
+              type: 'enum',
+              option: widgetId,
+              sourceText: widgetId,
+              utteranceText: widgetId,
+              resolution: {
+                value: widgetId
+              }
+            }
+          ],
+          skillConfigPath: SkillDomainHelper.getSkillConfigPath(
+            domain,
+            skill,
+            BRAIN.lang
+          ),
+          classification: {
+            domain,
+            skill,
+            action,
+            confidence: 1
+          },
+          ...params
+        })
+
+        const parsedOutput = JSON.parse(BRAIN.skillOutput)
+
+        if (parsedOutput.output.widget) {
+          message = 'Widget fetched successfully.'
+          LogHelper.title('POST /fetch-widget')
+          LogHelper.success(message)
+          return reply.send({
+            success: true,
+            status: 200,
+            code: 'widget_fetched',
+            message,
+            widget: parsedOutput.output.widget
+          })
+        }
+
+        message = 'Widget not fetched.'
+        LogHelper.title('POST /fetch-widget')
+        LogHelper.success(message)
+        return reply.send({
+          success: true,
+          status: 200,
+          code: 'widget_not_fetched',
+          message,
+          widget: null
+        })
+      } catch (e) {
+        LogHelper.title('HTTP Server')
+        LogHelper.error(`Failed to fetch widget component tree: ${e}`)
+
+        reply.statusCode = 500
+        return reply.send({
+          success: false,
+          status: reply.statusCode,
+          code: 'fetch_widget_error',
+          message: 'Failed to fetch widget component tree.',
+          widget: null
+        })
+      }
+    }
+  })
+}

--- a/server/src/core/http-server/http-server.ts
+++ b/server/src/core/http-server/http-server.ts
@@ -15,10 +15,10 @@ import { LogHelper } from '@/helpers/log-helper'
 import { DateHelper } from '@/helpers/date-helper'
 import { corsMidd } from '@/core/http-server/plugins/cors'
 import { otherMidd } from '@/core/http-server/plugins/other'
-import { infoPlugin } from '@/core/http-server/api/info'
+import { getInfo } from '@/core/http-server/api/info'
 import { llmInferencePlugin } from '@/core/http-server/api/llm-inference'
 import { runActionPlugin } from '@/core/http-server/api/run-action'
-import { fetchWidgetPlugin } from '@/core/http-server/api/fetch-widget'
+import { getFetchWidget, postFetchWidget } from '@/core/http-server/api/fetch-widget'
 import { keyMidd } from '@/core/http-server/plugins/key'
 import { utterancePlugin } from '@/core/http-server/api/utterance'
 import { LLM_MANAGER, PERSONA } from '@/core'
@@ -99,8 +99,9 @@ export default class HTTPServer {
     })
 
     this.fastify.register(runActionPlugin, { apiVersion: API_VERSION })
-    this.fastify.register(fetchWidgetPlugin, { apiVersion: API_VERSION })
-    this.fastify.register(infoPlugin, { apiVersion: API_VERSION })
+    this.fastify.register(getFetchWidget, { apiVersion: API_VERSION })
+    this.fastify.register(postFetchWidget, { apiVersion: API_VERSION })
+    this.fastify.register(getInfo, { apiVersion: API_VERSION })
     this.fastify.register(llmInferencePlugin, { apiVersion: API_VERSION })
 
     if (HAS_OVER_HTTP) {

--- a/server/src/core/socket-server.ts
+++ b/server/src/core/socket-server.ts
@@ -23,6 +23,8 @@ import {
 import { LogHelper } from '@/helpers/log-helper'
 import { LangHelper } from '@/helpers/lang-helper'
 import { Telemetry } from '@/telemetry'
+import { SkillDomainHelper } from '@/helpers/skill-domain-helper'
+import { DEFAULT_NLU_RESULT } from '@/core/nlu'
 
 interface HotwordDataEvent {
   hotword: string
@@ -214,6 +216,52 @@ export default class SocketServer {
                     action_params: params
                   }
                 )
+              } else if (method.methodName === 'fetch_widget_data') {
+                const { actionName, widgetId, params } = method.methodParams
+                const [domain, skill, action] = (actionName as string).split(':')
+
+                // Do not return any speech and new widget
+                BRAIN.isMuted = true
+                await BRAIN.execute({
+                  ...DEFAULT_NLU_RESULT,
+                  currentEntities: [
+                    {
+                      start: 0,
+                      end: (widgetId as string).length - 1,
+                      len: (widgetId as string).length,
+                      levenshtein: 0,
+                      accuracy: 1,
+                      entity: 'widgetid',
+                      type: 'enum',
+                      option: widgetId,
+                      sourceText: widgetId,
+                      utteranceText: widgetId,
+                      resolution: {
+                        value: widgetId
+                      }
+                    }
+                  ],
+                  skillConfigPath: SkillDomainHelper.getSkillConfigPath(
+                    domain,
+                    skill,
+                    BRAIN.lang
+                  ),
+                  classification: {
+                    domain,
+                    skill,
+                    action,
+                    confidence: 1
+                  },
+                  ...params
+                })
+
+                const parsedOutput = JSON.parse(BRAIN.skillOutput)
+
+                if (parsedOutput.output.widget) {
+                  this.socket?.emit('widget-data-fetched', {
+                    widget: parsedOutput.output.widget
+                  })
+                }
               }
             } catch (e) {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/skills/utilities/timer/src/widgets/components/timer.ts
+++ b/skills/utilities/timer/src/widgets/components/timer.ts
@@ -7,6 +7,7 @@ interface TimerProps {
   interval: number
   totalTimeContent: string
   onEnd?: () => WidgetEventMethod
+  onCheck?: () => WidgetEventMethod
 }
 
 export class Timer extends WidgetComponent<TimerProps> {

--- a/skills/utilities/timer/src/widgets/timer-widget.ts
+++ b/skills/utilities/timer/src/widgets/timer-widget.ts
@@ -13,7 +13,15 @@ interface Params {
 
 export class TimerWidget extends Widget<Params> {
   constructor(options: WidgetOptions<Params>) {
-    super(options)
+    super({
+      ...options,
+      onFetch: {
+        actionName: 'check_timer',
+        initialParams: {
+          id: options.params.id
+        }
+      }
+    })
 
     if (options.params.id) {
       this.id = options.params.id
@@ -52,6 +60,9 @@ export class TimerWidget extends Widget<Params> {
         return this.sendUtterance('times_up', {
           from: 'leon'
         })
+      },
+      onCheck: (): WidgetEventMethod => {
+        return this.fetchWidgetData(this.onFetch.actionName, [])
       }
     })
   }


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x] No

### List any relevant issue numbers:

### Description:
This PR introduces a new `onFetch` API for widgets, enabling them to dynamically fetch updated data from their respective skills after initial rendering. This moves widgets from static to dynamic, providing a more interactive user experience.

Key changes include:
*   **Widget SDKs:** Added an `onFetch` property to the `Widget` class (Node.js and Python) to specify a skill action for data fetching.
*   **Backend:** Implemented a new POST endpoint (`/api/v1/fetch-widget`) to handle dynamic widget data requests.
*   **Socket Server:** Modified the socket server to process `fetch_widget_data` events, execute the specified skill action, and emit `widget-data-fetched` back to the client. This centralizes widget event handling and avoids client-side HTTP requests for efficiency.
*   **Frontend:** Updated `chatbot.js` to listen for `widget-data-fetched` events and dynamically update the relevant widget in the DOM.
*   **Example:** The `timer` skill has been updated to demonstrate the new `onFetch` API, allowing users to refresh the timer's status via a new button.

---
<a href="https://cursor.com/background-agent?bcId=bc-f11663b3-a41c-4ea7-b6bd-721a8cd55b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f11663b3-a41c-4ea7-b6bd-721a8cd55b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

